### PR TITLE
Reverse color for command mode selection and hide concealed background

### DIFF
--- a/colors/amber.vim
+++ b/colors/amber.vim
@@ -25,6 +25,7 @@ if &background == "dark" " set background=dark
   hi ErrorMsg ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
   hi FoldColumn ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
   hi Folded ctermfg=94 ctermbg=233 cterm=none guifg=#875f00 guibg=#121212 gui=none
+  hi Conceal ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
   hi IncSearch ctermfg=none ctermbg=166 cterm=none guifg=#000000 guibg=#d75f00 gui=none
   hi LineNr ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
   hi MatchParen ctermfg=234 ctermbg=214 cterm=bold,reverse guifg=#1c1c1c guibg=#ffaf00 gui=bold,reverse
@@ -32,7 +33,7 @@ if &background == "dark" " set background=dark
   hi MoreMsg ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
   hi Pmenu ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
   hi PmenuSbar ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
-  hi PmenuSel ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
+  hi PmenuSel ctermfg=208 ctermbg=233 cterm=reverse guifg=#ff8700 guibg=#121212 gui=reverse
   hi PmenuThumb ctermfg=208 ctermbg=none cterm=reverse guifg=#ff8700 guibg=#000000 gui=reverse
   hi Question ctermfg=208 ctermbg=none cterm=none guifg=#ff8700 guibg=#000000 gui=none
   hi Search ctermfg=none ctermbg=166 cterm=none guifg=#000000 guibg=#d75f00 gui=none

--- a/colors/amber.vim
+++ b/colors/amber.vim
@@ -113,6 +113,7 @@ else
   hi ErrorMsg ctermfg=0 ctermbg=208 cterm=none guifg=#000000 guibg=#ff8700 gui=none
   hi FoldColumn ctermfg=0 ctermbg=208 cterm=none guifg=#000000 guibg=#ff8700 gui=none
   hi Folded ctermfg=233 ctermbg=94 cterm=none guifg=#121212 guibg=#875f00 gui=none
+  hi Conceal ctermfg=208 ctermbg=none cterm=none guifg=#000000 guibg=#ff8700 gui=none
   hi IncSearch ctermfg=0 ctermbg=166 cterm=none guifg=#000000 guibg=#d75f00 gui=none
   hi LineNr ctermfg=0 ctermbg=208 cterm=none guifg=#000000 guibg=#ff8700 gui=none
   hi MatchParen ctermfg=214 ctermbg=234 cterm=bold,reverse guifg=#ffaf00 guibg=#1c1c1c gui=bold,reverse
@@ -120,7 +121,7 @@ else
   hi MoreMsg ctermfg=0 ctermbg=208 cterm=none guifg=#000000 guibg=#ff8700 gui=none
   hi Pmenu ctermfg=0 ctermbg=208 cterm=none guifg=#000000 guibg=#ff8700 gui=none
   hi PmenuSbar ctermfg=0 ctermbg=208 cterm=none guifg=#000000 guibg=#ff8700 gui=none
-  hi PmenuSel ctermfg=0 ctermbg=208 cterm=none guifg=#000000 guibg=#ff8700 gui=none
+  hi PmenuSel ctermfg=0 ctermbg=208 cterm=none guifg=#ff8700 guibg=#000000 gui=none
   hi PmenuThumb ctermfg=0 ctermbg=208 cterm=reverse guifg=#000000 guibg=#ff8700 gui=reverse
   hi Question ctermfg=0 ctermbg=208 cterm=none guifg=#000000 guibg=#ff8700 gui=none
   hi Search ctermfg=0 ctermbg=166 cterm=none guifg=#000000 guibg=#d75f00 gui=none


### PR DESCRIPTION
Hi!

Thanks for creating this color scheme. It is exactly what I was looking for.

In my pull request, I have reversed the highlighting of the `PmenuSel` so that the selected item is in amber, and I have specified that the concealed background color is black.